### PR TITLE
Sites now attach to all user's groups

### DIFF
--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -49,6 +49,8 @@ class SiteController extends Controller
      */
     public function create(Request $request)
     {
+        $user = $request->user();
+
         $this->authorize('create', Site::class);
 
         $this->validate($request, [
@@ -77,6 +79,10 @@ class SiteController extends Controller
             'owner_name' => $request->owner_name,
             'owner_contact' => $request->owner_contact,
         ]);
+
+        foreach ($user->groups as $group) {
+            $group->sites()->attach($site->id);
+        }
 
         $site->species()->sync($request->species);
         $site->shrubs()->sync($request->shrubs);


### PR DESCRIPTION
#87 

When creating a site, it is automatically attached to all groups that the user is currently in

![image](https://user-images.githubusercontent.com/32902460/81000214-fa1dc800-8e13-11ea-9e7d-42dff3c4bde8.png)
