### PR TITLE
Added event page for non admins

### DIFF
--- a/app/Http/Controllers/EventsViewController.php
+++ b/app/Http/Controllers/EventsViewController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Event;
+use Illuminate\Http\Request;
+
+class EventsViewController extends Controller
+{
+    /**
+     * Show the Events page.
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function events()
+    {
+        $events = Event::get();
+
+        $events->transform(function (Event $event) {
+            if ($event->image !== null) {
+                $event->image->url = $event->image->makeUrl();
+            }
+
+            return $event;
+        });
+
+        return view('events.events', ['events' => $events]);
+    }
+
+    /**
+     * Show the page for an event.
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function event(Event $event)
+    {
+        if ($event->image !== null) {
+            $event->image->url = $event->image->makeUrl();
+        }
+
+        $event->starts_at = $event->event_start->isoFormat('MMM Do YYYY [at] H:mm');
+
+        if ($event->event_end) {
+            $event->starts_at = $event->event_start->isoFormat('MMM Do YYYY [at] H:mm');
+        }
+
+        return view('events.event', ['event' => $event]);
+    }
+}

--- a/resources/views/components/event_card.blade.php
+++ b/resources/views/components/event_card.blade.php
@@ -1,0 +1,21 @@
+<div class="col-lg-4">
+    <div class="mb-3 card position-relative">
+        <img class="card-img-top"
+             src="{{$event->image ? $event->image->url : '/img/placeholder.png'}}"/>
+        <div class="card-body">
+            <p class="font-weight-bold mb-1">{{$event->title}}</p>
+            <p class="text-muted small mb-0">
+                {{$event->event_start->isoFormat('MMM Do YYYY [at] H:mm') . " " . $event->timezone}}
+            </p>
+            <p class="text-muted small">{{$event->address}}</p>
+            <span class="text-muted d-block text-overflow-ellipsis no-wrap" :title="{{$event->description}}">
+                {{$event->description}}
+            </span>
+        </div>
+        <div class="card-footer pt-0 d-flex px-2 pb-2 align-items-center">
+            <a href="{{"/event/$event->id"}}" class="btn btn-link">
+                Learn More
+            </a>
+        </div>
+    </div>
+</div>

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -14,6 +14,21 @@
         <div class="collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
             <ul class="navbar-nav">
                 <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle font-weight-bold{{ Route::is('contact') ? ' active' : ''}}"
+                       href="#"
+                       id="contactDropdown"
+                       role="button"
+                       data-toggle="dropdown"
+                       aria-haspopup="true"
+                       aria-expanded="false">
+                        Contact Us
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="contactDropdown">
+                        <a class="dropdown-item" href="#">Contact Form</a>
+                        <a class="dropdown-item" href="/events">Events and Training</a>
+                    </div>
+                </li>
+                <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle font-weight-bold{{ Route::is('getting-started') ? ' active' : ''}}"
                        href="#"
                        id="guidesDropdown"

--- a/resources/views/events/event.blade.php
+++ b/resources/views/events/event.blade.php
@@ -4,12 +4,6 @@
     <div>
         @include('components.navbar')
         <div class="container py-4">
-            <div class="mb-4">
-                <a href="/events" class="d-flex align-items-center">
-                    <ion-icon class="icon" name="arrow-back-outline"></ion-icon>
-                    <span class="ml-2">Events</span>
-                </a>
-            </div>
             <div class="row flex-column-reverse flex-md-row">
                 <div class="col-md-8">
                     <div class="card">

--- a/resources/views/events/event.blade.php
+++ b/resources/views/events/event.blade.php
@@ -1,0 +1,69 @@
+@extends('layouts.guest')
+
+@section('content')
+    <div>
+        @include('components.navbar')
+        <div class="container py-4">
+            <div class="mb-4">
+                <a href="/events" class="d-flex align-items-center">
+                    <ion-icon class="icon" name="arrow-back-outline"></ion-icon>
+                    <span class="ml-2">Events</span>
+                </a>
+            </div>
+            <div class="row flex-column-reverse flex-md-row">
+                <div class="col-md-8">
+                    <div class="card">
+                        @if ($event->image)
+                            <img class="img-fluid img-fit" src="{{$event->image->url}}"/>
+                        @endif
+                        <div class="card-body">
+                            <h1 class="mb-2">{{$event->title}}</h1>
+                            <p>{!! $event->description !!}</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card mb-3">
+                        <div class="card-body">
+                            <div class="pb-2">
+                                <strong>Event Information</strong>
+                            </div>
+                            <dl class="mb-0">
+                                <dt>Start Time</dt>
+                                <dd class="text-muted">
+                                    {{$event->event_start->isoFormat('MMM Do, YYYY [at] H:mm') . " " . $event->timezone}}
+                                </dd>
+
+                                <dt>End Time</dt>
+                                <dd class="text-muted">
+                                    {{$event->event_end ? $event->event_end->isoFormat('MMM Do, YYYY [at] H:mm') . " " . $event->timezone : 'Not provided'}}
+                                </dd>
+
+                                <dt>Event Type</dt>
+                                <dd class="text-muted">{{$event->event_type}}</dd>
+
+                                <dt>Address</dt>
+                                <dd class="text-muted">
+                                    {{$event->address ?? 'Not provided'}}
+                                </dd>
+
+                                <dt>Contact Info</dt>
+                                <dd class="text-muted">
+                                    {{$event->contact_info ?? 'Not provided'}}
+                                </dd>
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <style>
+        .img-fit {
+            object-fit: cover;
+            width: 100%;
+            height: 400px;
+        }
+    </style>
+@endsection

--- a/resources/views/events/events.blade.php
+++ b/resources/views/events/events.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.guest')
+
+@section('content')
+    <div>
+        @include('components.navbar')
+        <div class="container py-4">
+            <div class="col-12">
+                <h1 class="mb-4">Events</h1>
+                <div class="row">
+                    @each('components.event_card', $events, 'event')
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <style scoped>
+        .text-overflow-ellipsis {
+            display: block;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .card-img-top {
+            object-fit: cover;
+            width: 100%;
+            height: 200px;
+        }
+    </style>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,9 @@ Route::get('/web/images/storage/{image}', 'ImageController@serve');
 
 Route::get('/', 'HomeController@index')->name('home');
 
+Route::get('/events', 'EventsViewController@events')->name('events');
+Route::get('/event/{event}', 'EventsViewController@event')->name('event');
+
 // About
 Route::get('/about', 'AboutController@about')->name('about');
 Route::get('/about/benefits', 'AboutController@benefits')->name('benefits');


### PR DESCRIPTION
#196 

All events are viewable at `/events` (Events and Training under the Contact Us dropdown)

![image](https://user-images.githubusercontent.com/32902460/84422680-5d590200-abeb-11ea-985c-2e5fc5206949.png)

A single event can be viewed by clicking Learn More

![image](https://user-images.githubusercontent.com/32902460/84422785-87aabf80-abeb-11ea-82e8-8aff247cd08d.png)

Note that an event without an image will be displayed without the image on the actual page because I thought it would be redundant to have a placeholder image taking up half the page