### PR TITLE
Resources are now deleted properly

### DIFF
--- a/app/Console/Commands/DeleteUnattachedResources.php
+++ b/app/Console/Commands/DeleteUnattachedResources.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Plot;
+use App\Plant;
+use App\Measurement;
+use Illuminate\Console\Command;
+
+class DeleteUnattachedResources extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'delete:unattached';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Deletes any plots, plants, or measurements that no longer belong to an existing resource.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $count = 0;
+
+        $count += Plot::whereDoesntHave('site')->delete();
+        $count += Plant::whereDoesntHave('plot')->delete();
+        $count += Measurement::whereDoesntHave('plant')->delete();
+
+        $this->info("Deleted $count unattached resources.");
+    }
+}

--- a/app/Events/PlantDeleted.php
+++ b/app/Events/PlantDeleted.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Events;
+
+use App\Plant;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PlantDeleted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $plant;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Plant $plant)
+    {
+        $this->plant = $plant;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Events/PlotDeleted.php
+++ b/app/Events/PlotDeleted.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Events;
+
+use App\Plot;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PlotDeleted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var \App\Plot
+     */
+    public $plot;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Plot $plot)
+    {
+        $this->plot = $plot;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Events/SiteDeleted.php
+++ b/app/Events/SiteDeleted.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Events;
+
+use App\Site;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SiteDeleted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var \App\Site
+     */
+    public $site;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Site $site)
+    {
+        $this->site = $site;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Listeners/DeleteAttachedMeasurementsListener.php
+++ b/app/Listeners/DeleteAttachedMeasurementsListener.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DeleteAttachedMeasurementsListener implements ShouldQueue
+{
+    /**
+     * Handle the event.
+     *
+     * @param \App\Events\PlantDeleted $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        $plant = $event->plant;
+
+        $plant->measurements()->delete();
+    }
+}

--- a/app/Listeners/DeleteAttachedPlantsListener.php
+++ b/app/Listeners/DeleteAttachedPlantsListener.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DeleteAttachedPlantsListener implements ShouldQueue
+{
+    /**
+     * Handle the event.
+     *
+     * @param \App\Events\PlotDeleted $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        $plot = $event->plot;
+
+        $plot->plants->each(function ($plant) {
+            $plant->delete();
+        });
+    }
+}

--- a/app/Listeners/DeleteAttachedPlotsListener.php
+++ b/app/Listeners/DeleteAttachedPlotsListener.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DeleteAttachedPlotsListener implements ShouldQueue
+{
+    /**
+     * Handle the event.
+     *
+     * @param \App\Events\SiteDeleted $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        $site = $event->site;
+
+        $site->plots->each(function ($plot) {
+            $plot->delete();
+        });
+    }
+}

--- a/app/Plant.php
+++ b/app/Plant.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Events\PlantDeleted;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -22,6 +23,13 @@ class Plant extends Model
         'collected_at',
         'stems',
         'flowers',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $dispatchesEvents = [
+        'deleted' => PlantDeleted::class,
     ];
 
     /**

--- a/app/Plot.php
+++ b/app/Plot.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Events\PlotDeleted;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -27,6 +28,13 @@ class Plot extends Model
         'recorders',
         'last_measured_at',
         'wmu',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $dispatchesEvents = [
+        'deleted' => PlotDeleted::class,
     ];
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,9 +4,15 @@ namespace App\Providers;
 
 use App\Events\InvitationAccepted;
 use App\Events\InvitationCreated;
+use App\Events\SiteDeleted;
 use App\Events\PlotCreated;
 use App\Events\PlotUpdated;
+use App\Events\PlotDeleted;
+use App\Events\PlantDeleted;
 use App\Listeners\AttachAddressToPlotListener;
+use App\Listeners\DeleteAttachedPlotsListener;
+use App\Listeners\DeleteAttachedPlantsListener;
+use App\Listeners\DeleteAttachedMeasurementsListener;
 use App\Listeners\InvitationAcceptedListener;
 use App\Listeners\SendInvitationListener;
 use App\Listeners\AttachWMUToPlotListener;
@@ -26,6 +32,9 @@ class EventServiceProvider extends ServiceProvider
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],
+        SiteDeleted::class => [
+            DeleteAttachedPlotsListener::class,
+        ],
         PlotCreated::class => [
             AttachAddressToPlotListener::class,
             AttachWMUToPlotListener::class,
@@ -33,6 +42,12 @@ class EventServiceProvider extends ServiceProvider
         PlotUpdated::class => [
             AttachAddressToPlotListener::class,
             AttachWMUToPlotListener::class,
+        ],
+        PlotDeleted::class => [
+            DeleteAttachedPlantsListener::class,
+        ],
+        PlantDeleted::class => [
+            DeleteAttachedMeasurementsListener::class,
         ],
         InvitationCreated::class => [
             SendInvitationListener::class

--- a/app/Site.php
+++ b/app/Site.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Events\SiteDeleted;
 use App\Events\SiteUpdatedEvent;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -27,8 +28,12 @@ class Site extends Model
         'last_measured_at',
     ];
 
+    /**
+     * @var array
+     */
     protected $dispatchesEvents = [
-        'updated' => SiteUpdatedEvent::class
+        'updated' => SiteUpdatedEvent::class,
+        'deleted' => SiteDeleted::class,
     ];
 
     /**


### PR DESCRIPTION
#246 

When site / plot / plant is deleted, any attached resources (measurements attached to plants, plants attached to plots, etc.) will also be deleted.

To fix any unattached resources floating around in the database prior to this fix, there is a command `delete:unattached` that will clean them for you.