### PR TITLE
Fixed a bug with the statistics card

### DIFF
--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -49,7 +49,7 @@ class StatisticsController extends Controller
 
         $sites = Site::orderBy('name', 'asc');
 
-        if ($request->data_type === 'owned') {
+        if ($request->data_type !== 'admin') {
             $sites->where('user_id', $user->id);
         }
 
@@ -89,7 +89,7 @@ class StatisticsController extends Controller
 
         $plots = Plot::orderBy('number', 'asc');
 
-        if ($request->data_type === 'owned') {
+        if ($request->data_type !== 'admin') {
             $plots->where('user_id', $user->id);
         }
 


### PR DESCRIPTION
When data type was null, the stats page was pulling all sites instead of just the ones that belonged to the user. This has been fixed.