### PR TITLE
Reminders no longer sent if site doesnt send reminders

### DIFF
--- a/app/Jobs/SendReminders.php
+++ b/app/Jobs/SendReminders.php
@@ -27,6 +27,9 @@ class SendReminders implements ShouldQueue
             ->whereDoesntHave('reminder', function ($query) {
                 $query->whereDate('sent_at', now());
             })
+            ->whereHas('site', function ($query) {
+                $query->where('sends_reminders', 1);
+            })
             ->with(['reminder'])
             ->cursor();
 


### PR DESCRIPTION
I allowed users to set a `send_reminders` boolean on the site page but never actually used this boolean anywhere. This is now checked before reminders are sent out so that users are only notified if they have the site reminders turned on 