### PR TITLE
Added sites of group owner to group

### DIFF
--- a/app/Console/Commands/UpdateGroupSites.php
+++ b/app/Console/Commands/UpdateGroupSites.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Group;
+use Illuminate\Console\Command;
+
+class UpdateGroupSites extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'update:group-sites';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Detach and reattach all sites for every group';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $groups = Group::cursor();
+        $group_count = 0;
+
+        foreach ($groups as $group) {
+          $users = $group->users()->cursor();
+          $group_count++;
+
+          foreach ($users as $user) {
+            $sites = $user->sites()->select(['sites.id'])->get()->pluck('id');
+            $group->sites()->syncWithoutDetaching($sites);
+          }
+        }
+
+        $this->info("Updated sites for $group_count groups.");
+    }
+}

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -64,6 +64,9 @@ class GroupController extends Controller
             'name' => $request->name,
         ]);
 
+        $sites = $user->sites()->select(['sites.id'])->get()->pluck('id');
+        $group->sites()->syncWithoutDetaching($sites);
+
         $group->users()->attach($user->id);
 
         return $this->created($group);


### PR DESCRIPTION
#297 

When creating a group, the owner's sites are now properly added to the group. A new command `update:group-sites` was added to fix any groups created prior to this change.