### PR TITLE
Added instructions to the downloadable spreadsheet

### DIFF
--- a/app/Exports/SiteExport.php
+++ b/app/Exports/SiteExport.php
@@ -8,9 +8,15 @@ use App\Plot;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Concerns\RegistersEventListeners;
+use Maatwebsite\Excel\Events\AfterSheet;
+use Maatwebsite\Excel\Events\BeforeSheet;
 
-class SiteExport implements FromCollection, WithHeadings, ShouldAutoSize
+class SiteExport implements FromCollection, WithHeadings, WithEvents
 {
+    use RegistersEventListeners;
+
     /** @var User $user */
     protected $user;
 
@@ -90,5 +96,46 @@ class SiteExport implements FromCollection, WithHeadings, ShouldAutoSize
         }
 
         return $rows;
+    }
+
+    public static function beforeSheet(BeforeSheet $event)
+    {
+        $event->sheet->autoSize();
+    }
+
+    public static function afterSheet(AfterSheet $event)
+    {
+        $sheet = $event->sheet->getDelegate();
+
+        $instructions = "To add your spreadsheet data to AVID, you must do the following:\n" .
+            "\t1. Fill out the date and height columns (Columns I and J).\n" .
+            "\tAny other columns modified will not be reflected on upload.\n" .
+            "\t2. Save the document, return to the site page, click the 'Import Spreadsheet'\n" .
+            "\tbutton under the Actions block, and select this spreadsheet.\n" .
+            "Once the import is completed, you should see new measurements for each of your plants.";
+
+        $sheet->insertNewRowBefore(1);
+        $sheet->setCellValue('A1', $instructions);
+
+        $sheet->getColumnDimension('A')->setAutoSize(false);
+        foreach(range('B','J') as $columnID) {
+            $sheet->getColumnDimension($columnID)->setAutoSize(true);
+        }
+
+        // Manually auto-size the first column by the site name (ignore the instructions row).
+        $site_name = $sheet->getCell('A2')->getValue();
+        $sheet->getColumnDimension('A')->setWidth(strlen($site_name) * 4.0);
+
+        // Adjust header row height.
+        $sheet->getRowDimension(1)->setRowHeight(90);
+
+        // Set the background color to green.
+        $sheet->getStyle('A1:J1')->getFill()
+          ->setFillType(\PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID)
+          ->getStartColor()->setARGB('2eb07a');
+
+        // Set the font color to white.
+        $sheet->getStyle('A1:J1')->getFont()
+          ->getColor()->setARGB('ffffff');
     }
 }

--- a/app/Imports/SiteImport.php
+++ b/app/Imports/SiteImport.php
@@ -119,4 +119,14 @@ class SiteImport implements ToModel, WithHeadingRow, WithValidation
             ],
         ];
     }
+
+    /**
+     * Skip the instructions row.
+     *
+     * @return int
+     */
+    public function headingRow(): int
+    {
+        return 2;
+    }
 }


### PR DESCRIPTION
#370 

Instructions have been added to the top of the exported spreadsheet.

![image](https://user-images.githubusercontent.com/32902460/102097970-953c3e80-3df4-11eb-88d8-18cf7c94913f.png)

The importer has been updated to compensate for the new row.